### PR TITLE
flake: checks: add formatting checks for rust and nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
             ];
           } ''
             cd $src
-            cargo fmt --check
+            cargo fmt --check --message-format short
             touch $out
           '';
           formatting-nix = pkgs.runCommandNoCCLocal "check-nix-formatting" {

--- a/flake.nix
+++ b/flake.nix
@@ -31,30 +31,7 @@
       }) pkgsFor;
 
       checks = lib.mapAttrs (system: pkgs:
-        (lib.mapAttrs' (name: value: {
-          name = "build-${name}";
-          inherit value;
-        }) self.packages.${system}) // {
-          formatting-rust = pkgs.runCommandNoCCLocal "check-rust-formatting" {
-            src = self;
-            nativeBuildInputs = [
-              (pkgs.rust-bin.selectLatestNightlyWith (toolchain:
-                toolchain.minimal.override { extensions = [ "rustfmt" ]; }))
-            ];
-          } ''
-            cd $src
-            cargo fmt --check --message-format short
-            touch $out
-          '';
-          formatting-nix = pkgs.runCommandNoCCLocal "check-nix-formatting" {
-            src = self;
-            nativeBuildInputs = [ pkgs.nixfmt-classic ];
-          } ''
-            cd $src
-            nixfmt --check .
-            touch $out
-          '';
-        }) pkgsFor;
+        pkgs.callPackages ./nix/checks.nix { inherit self lib pkgs; }) pkgsFor;
 
       devShells = lib.mapAttrs (system: pkgs: {
         default = pkgs.callPackage ./nix/shell.nix { inherit packageName; };

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,14 @@
             cargo fmt --check
             touch $out
           '';
+          formatting-nix = pkgs.runCommandNoCCLocal "check-nix-formatting" {
+            src = self;
+            nativeBuildInputs = [ pkgs.nixfmt-classic ];
+          } ''
+            cd $src
+            nixfmt --check .
+            touch $out
+          '';
         }) pkgsFor;
 
       devShells = lib.mapAttrs (system: pkgs: {

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,0 +1,31 @@
+{ self, lib, pkgs }:
+let
+  inherit (pkgs.stdenv.hostPlatform) system;
+
+  packageChecks = lib.mapAttrs' (name: value: {
+    name = "build-${name}";
+    inherit value;
+  }) self.packages.${system};
+
+in packageChecks // {
+  formatting-rust = pkgs.runCommandNoCCLocal "check-rust-formatting" {
+    src = self;
+    nativeBuildInputs = [
+      (pkgs.rust-bin.selectLatestNightlyWith
+        (toolchain: toolchain.minimal.override { extensions = [ "rustfmt" ]; }))
+    ];
+  } ''
+    cd $src
+    cargo fmt --check --message-format short
+    touch $out
+  '';
+
+  formatting-nix = pkgs.runCommandNoCCLocal "check-nix-formatting" {
+    src = self;
+    nativeBuildInputs = [ pkgs.nixfmt-classic ];
+  } ''
+    cd $src
+    nixfmt --check .
+    touch $out
+  '';
+}


### PR DESCRIPTION
I'm not sure that `runCommandNoCCLocal` is the right function to use.

On one hand, sending derivations plus source code over the network to
run the formatting checks on another machine would probably be very
wasteful. On the other, keeping this work local means it will probably
be slow to process large codebases on a low-end device, and then
spending the bandwidth may have been worth it.

Also, for some reason in the past, I had decided that `runCommand` was
unsuitable for this type of check, and that it was better to customize
`mkDerivation`'s arguments for the sake of putting the script in
`checkPhase` alone. Since I don't remember my reasoning from that time,
I have opted to just follow what others do, and use `runCommand`.

For future reference, I'm talking about the formatting check for
Hyprnix, found here:
<https://github.com/hyprland-community/hyprnix/blob/30f0e3532cf46080d6b9bcf7b95e3f6d05d8fb43/flake.nix#L70-L85>