### PR TITLE
nix: add treewide formatter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
         default = pkgs.callPackage ./nix/shell.nix { inherit packageName; };
       }) pkgsFor;
 
-      formatter =
-        eachSystem (system: nixpkgs.legacyPackages.${system}.nixfmt-classic);
+      formatter = lib.mapAttrs (system: pkgs:
+        pkgs.callPackage ./nix/formatter.nix { inherit packageName; }) pkgsFor;
     };
 }

--- a/nix/formatter.nix
+++ b/nix/formatter.nix
@@ -7,6 +7,16 @@ writeShellApplication {
       (toolchain: toolchain.minimal.override { extensions = [ "rustfmt" ]; }))
   ];
   text = ''
+    bad_usage() {
+      echo -e "\033[31merror:\033[0m $1" >&2
+      echo -e "\033[33mUsage:\033[0m $(basename "$0") [ . | -- ]" >&2
+      exit 1
+    }
+
+    if [ "$#" -gt 1 ]; then
+      bad_usage "too many arguments"
+    fi
+
     src="''${1:-.}"
     case "$src" in
       --)
@@ -17,8 +27,7 @@ writeShellApplication {
         cargo fmt
         ;;
       *)
-        echo "Usage: $(basename "$0") [ . | -- ]" >&2
-        exit 1
+        bad_usage "unknown argument '$src'"
         ;;
     esac
   '';

--- a/nix/formatter.nix
+++ b/nix/formatter.nix
@@ -1,0 +1,25 @@
+{ nixfmt-classic, rust-bin, writeShellApplication, packageName }:
+writeShellApplication {
+  name = "${packageName}-treewide-formatter";
+  runtimeInputs = [
+    nixfmt-classic
+    (rust-bin.selectLatestNightlyWith
+      (toolchain: toolchain.minimal.override { extensions = [ "rustfmt" ]; }))
+  ];
+  text = ''
+    src="''${1:-.}"
+    case "$src" in
+      --)
+        nixfmt --
+        ;;
+      .)
+        nixfmt .
+        cargo fmt
+        ;;
+      *)
+        echo "Usage: $(basename "$0") [ . | -- ]" >&2
+        exit 1
+        ;;
+    esac
+  '';
+}


### PR DESCRIPTION
Introduce a simple script that handles exactly two cases:

- Formatting Nix code from *stdin*, e.g., when the editor is
  configured to use `nix fmt -- --` as the default Nix formatter.
- Formatting the entire source tree from the current working directory.

In the latter case, both `nixfmt .` and `cargo fmt` are invoked.

It is intentional that `--all` is not passed to `cargo fmt`.

Arbitrary file paths are not supported, as indicated by the usage text,
which is printed to *stderr* if an unexpected argument is provided.