### PR TITLE
fix: don't stackoverflow when `inputs.*.follows = ""`

### DIFF
--- a/src/flake_lock.rs
+++ b/src/flake_lock.rs
@@ -214,7 +214,11 @@ impl LockFile {
     }
 
     pub fn follow_path(&self, path: impl IntoIterator<Item = impl AsRef<str>>) -> Option<String> {
-        path.into_iter().try_fold(self.root.clone(), |index, name| {
+        let mut iter = path.into_iter().peekable();
+        if iter.peek().is_none() {
+            return None;
+        }
+        iter.try_fold(self.root.clone(), |index, name| {
             self.resolve_edge(&*self.get_node(index)?.get_edge(name)?)
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,10 +225,19 @@ fn substitute_node_inputs_with_root_inputs(lock: &LockFile, node: &Node, indexed
                 elogln!("-", :yellow "'{edge_name}'", "now follows", :green "'{edge}'", :dimmed "(was '{old}')");
             }
         } else {
-            elogln!(
-                :bold (:cyan "No suitable replacement for", :yellow "'{edge_name}'"),
-                :dimmed "(" :dimmed :italic ("'" (lock.resolve_edge(&edge).unwrap()) "'") :dimmed ")"
-            );
+            if let Some(resolved_edge) = lock.resolve_edge(&edge) {
+                elogln!(
+                    :bold (:cyan "No suitable replacement for", :yellow "'{edge_name}'"),
+                    :dimmed "(" :dimmed :italic ("'" (resolved_edge) "'") :dimmed ")"
+                );
+            } else {
+                elogln!(
+                    "-",
+                    (:yellow :italic "'{edge_name}'"),
+                    "does not resolve to anything",
+                    :dimmed "(probably because", (:dimmed :italic "follows = \"\"") :dimmed ")"
+                );
+            }
         }
     }
 }
@@ -255,8 +264,9 @@ fn recurse_inputs(lock: &LockFile, index: String, op: &mut impl FnMut(String)) {
     let node = lock.get_node(&index).unwrap();
     op(index);
     for (_, edge) in node.iter_edges() {
-        let index = lock.resolve_edge(&edge).unwrap();
-        recurse_inputs(lock, index, op);
+        if let Some(index) = lock.resolve_edge(&edge) {
+            recurse_inputs(lock, index, op);
+        }
     }
 }
 


### PR DESCRIPTION
Previously, the path resolver would recur on itself if it found that `follows = ""`. Normally in nix flakes, nix would just dismiss the input. So in that case we can return `None` in `follow_path`.