### PR TITLE
main: substitute: skip inputs with different origins

### DIFF
--- a/samples/input-collision/flake.lock
+++ b/samples/input-collision/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "root": {
+      "inputs": {
+        "tokyonight": "tokyonight"
+      }
+    },
+    "tokyonight": {
+      "inputs": {
+        "tokyonight": "tokyonight_2",
+        "tokyonight-rofi": "tokyonight-rofi"
+      },
+      "locked": {
+        "lastModified": 1744398025,
+        "narHash": "sha256-NhxZ0ZtNeupQ3/Rk3RQwRPgcSwGVExRR7mELFlRsq1U=",
+        "owner": "mrjones2014",
+        "repo": "tokyonight.nix",
+        "rev": "c78baee8d8ef560fe81156b952c99b1f8e649a5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrjones2014",
+        "repo": "tokyonight.nix",
+        "type": "github"
+      }
+    },
+    "tokyonight-rofi": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1710787931,
+        "narHash": "sha256-bgRt1TEMSju4NzFu7jtLzGNBtKE7HHS+mscGYHK0xBM=",
+        "owner": "w8ste",
+        "repo": "Tokyonight-rofi-theme",
+        "rev": "7400f6c3cc1ae5fa6c21c3dfce2421e6ee94322c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "w8ste",
+        "repo": "Tokyonight-rofi-theme",
+        "type": "github"
+      }
+    },
+    "tokyonight_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718132322,
+        "narHash": "sha256-KaGzxJGiNGziDT8vLZcLjU26//OcL3/tmmu5dYB6w1c=",
+        "owner": "folke",
+        "repo": "tokyonight.nvim",
+        "rev": "024621763d91bb48f2b486df529c7aaeb8d6d355",
+        "type": "github"
+      },
+      "original": {
+        "owner": "folke",
+        "repo": "tokyonight.nvim",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/samples/input-collision/flake.nix
+++ b/samples/input-collision/flake.nix
@@ -1,0 +1,4 @@
+{
+  inputs = { tokyonight.url = "github:mrjones2014/tokyonight.nix"; };
+  outputs = { ... }: { };
+}

--- a/src/flake_lock.rs
+++ b/src/flake_lock.rs
@@ -195,9 +195,19 @@ impl LockFile {
         self.nodes.get(index.as_ref()).map(RefCell::borrow)
     }
 
-    #[expect(unused)]
     pub fn get_node_mut(&self, index: impl AsRef<str>) -> Option<RefMut<Node>> {
         self.nodes.get(index.as_ref()).map(RefCell::borrow_mut)
+    }
+
+    pub fn get_node_by_edge(&self, edge: &NodeEdge) -> Option<Ref<Node>> {
+        self.resolve_edge(edge)
+            .and_then(|index| self.get_node(index))
+    }
+
+    #[expect(unused)]
+    pub fn get_node_by_edge_mut(&self, edge: &NodeEdge) -> Option<RefMut<Node>> {
+        self.resolve_edge(edge)
+            .and_then(|index| self.get_node_mut(index))
     }
 
     pub fn remove_node(&mut self, index: impl AsRef<str>) -> Option<Node> {

--- a/src/flake_lock.rs
+++ b/src/flake_lock.rs
@@ -39,8 +39,8 @@ pub struct LockedNode {
     pub flake: bool,
     #[serde(skip_serializing_if = "IndexMap::is_empty", default)]
     pub inputs: IndexMap<String, RefCell<NodeEdge>>,
-    pub locked: serde_json::Value,
-    pub original: serde_json::Value,
+    pub locked: IndexMap<String, serde_json::Value>,
+    pub original: IndexMap<String, serde_json::Value>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]

--- a/src/flake_lock.rs
+++ b/src/flake_lock.rs
@@ -36,17 +36,17 @@ pub enum Node {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct LockedNode {
     #[serde(skip_serializing_if = "Clone::clone", default = "default_true")]
-    flake: bool,
+    pub flake: bool,
     #[serde(skip_serializing_if = "IndexMap::is_empty", default)]
-    inputs: IndexMap<String, RefCell<NodeEdge>>,
-    locked: serde_json::Value,
-    original: serde_json::Value,
+    pub inputs: IndexMap<String, RefCell<NodeEdge>>,
+    pub locked: serde_json::Value,
+    pub original: serde_json::Value,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct UnlockedNode {
-    inputs: IndexMap<String, RefCell<NodeEdge>>,
+    pub inputs: IndexMap<String, RefCell<NodeEdge>>,
 }
 
 impl NodeEdge {

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,10 @@ fn read_flake_lock(lock_file: Input) -> LockFile {
             .unwrap_or_else(|e| panic!("Failed to deserialize the provided flake lock: {e}"))
     };
 
+    lock
+}
+
+fn sanity_check_flake_lock(lock: &LockFile) {
     if lock.version() < MIN_SUPPORTED_LOCK_VERSION && lock.version() > MAX_SUPPORTED_LOCK_VERSION {
         panic!(
             "This program supports lock files between schema versions {} and {} while the flake you have asked to modify is of version {}.",
@@ -175,10 +179,6 @@ fn read_flake_lock(lock_file: Input) -> LockFile {
         );
     }
 
-    lock
-}
-
-fn sanity_check_flake_lock(lock: &LockFile) {
     for (index, node) in lock
         .node_indices()
         .map(|index| (index, lock.get_node(index).unwrap()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,7 @@ fn main() {
                 },
         } => {
             let mut lock = read_flake_lock(lock_file);
+            sanity_check_flake_lock(&lock);
 
             let node_hits = FlakeNodeVisits::count_from_index(&lock, lock.root_index());
             eprintln!();
@@ -143,6 +144,7 @@ fn main() {
                 },
         } => {
             let lock = read_flake_lock(lock_file);
+            sanity_check_flake_lock(&lock);
             let node_hits = FlakeNodeVisits::count_from_index(&lock, lock.root_index());
             if json {
                 serialize_to_json_output(&*node_hits, output, overwrite, pretty)
@@ -174,6 +176,21 @@ fn read_flake_lock(lock_file: Input) -> LockFile {
     }
 
     lock
+}
+
+fn sanity_check_flake_lock(lock: &LockFile) {
+    for (index, node) in lock
+        .node_indices()
+        .map(|index| (index, lock.get_node(index).unwrap()))
+    {
+        if index != "root" && matches!(&*node, Node::Unlocked(_)) {
+            panic!(
+                "This lock file has an unlocked input named '{index}'.\n\
+                This is almost certainly the result of using a buggy version of Nix.\n\
+                Please ensure that Nix is up-to-date and try re-generating the lock file."
+            );
+        }
+    }
 }
 
 fn serialize_to_json_output(value: impl Serialize, output: Output, overwrite: bool, pretty: bool) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use serde_json::Serializer;
 
 static EXPECT_ROOT_EXIST: &str = "the root node to exist";
+static MISSED_SANITY_CHECK: &str = "ensure that sanity_check_lock_file is called before this point";
 
 /// Imitate Nix flake input following behavior as a post-process,
 /// so that you can stop manually maintaining tedious connections
@@ -232,20 +233,26 @@ fn substitute_flake_inputs_with_follows(lock: &LockFile, indexed: bool) {
 /// verbatim from the root node, most likely retaining a `NodeEdge::Indexed`.
 fn substitute_node_inputs_with_root_inputs(lock: &LockFile, node: &Node, indexed: bool) {
     let root = lock.root().expect(EXPECT_ROOT_EXIST);
-    for (edge_name, mut edge) in node.iter_edges_mut() {
-        if let Some(root_edge) = root.get_edge(edge_name) {
-            if indexed {
-                let old = std::mem::replace(&mut *edge, (*root_edge).clone());
-                elogln!("-", :yellow "'{edge_name}'", "now references", :italic :purple "'{edge}'", :dimmed "(was '{old}')");
-            } else {
-                let old = std::mem::replace(&mut *edge, NodeEdge::from_iter([edge_name]));
-                elogln!("-", :yellow "'{edge_name}'", "now follows", :green "'{edge}'", :dimmed "(was '{old}')");
-            }
-        } else {
+    for (input_name, mut node_edge) in node.iter_edges_mut() {
+        let Some(root_edge) = root.get_edge(input_name) else {
             elogln!(
-                :bold (:cyan "No suitable replacement for", :yellow "'{edge_name}'"),
-                :dimmed "(" :dimmed :italic ("'" (lock.resolve_edge(&edge).unwrap()) "'") :dimmed ")"
+                :bold (:cyan "No suitable replacement for", :yellow "'{input_name}'"),
+                :dimmed "(" :dimmed :italic ("'" (lock.resolve_edge(&node_edge).unwrap()) "'") :dimmed ")"
             );
+            continue;
+        };
+        let Node::Locked(_input) = &*lock.get_node_by_edge(&node_edge).unwrap() else {
+            unreachable!("{}", MISSED_SANITY_CHECK);
+        };
+        let Node::Locked(_root_input) = &*lock.get_node_by_edge(&root_edge).unwrap() else {
+            unreachable!("{}", MISSED_SANITY_CHECK);
+        };
+        if indexed {
+            let old = std::mem::replace(&mut *node_edge, (*root_edge).clone());
+            elogln!("-", :yellow "'{input_name}'", "now references", :italic :purple "'{node_edge}'", :dimmed "(was '{old}')");
+        } else {
+            let old = std::mem::replace(&mut *node_edge, NodeEdge::from_iter([input_name]));
+            elogln!("-", :yellow "'{input_name}'", "now follows", :green "'{node_edge}'", :dimmed "(was '{old}')");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,12 +241,23 @@ fn substitute_node_inputs_with_root_inputs(lock: &LockFile, node: &Node, indexed
             );
             continue;
         };
-        let Node::Locked(_input) = &*lock.get_node_by_edge(&node_edge).unwrap() else {
+        let Node::Locked(input) = &*lock.get_node_by_edge(&node_edge).unwrap() else {
             unreachable!("{}", MISSED_SANITY_CHECK);
         };
-        let Node::Locked(_root_input) = &*lock.get_node_by_edge(&root_edge).unwrap() else {
+        let Node::Locked(root_input) = &*lock.get_node_by_edge(&root_edge).unwrap() else {
             unreachable!("{}", MISSED_SANITY_CHECK);
         };
+        if input.original != root_input.original {
+            elogln!(
+                :bold (
+                    :bright_red "Skipping", :cyan "replacement for", :yellow "'{node_edge}'",
+                    :cyan "because", :purple "'{root_edge}'", :cyan "has a different origin."
+                );
+                (,, :yellow "Transitive input:", :blue (input.original));
+                (,, :purple "Top-level input:", :blue (root_input.original))
+            );
+            continue;
+        }
         if indexed {
             let old = std::mem::replace(&mut *node_edge, (*root_edge).clone());
             elogln!("-", :yellow "'{input_name}'", "now references", :italic :purple "'{node_edge}'", :dimmed "(was '{old}')");

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ enum Command {
         output_opts: OutputOptions,
         /// The path of `flake.lock` to read, or `-` to read from standard input.
         /// If unspecified, defaults to the current directory.
-        #[bpaf(positional("INPUT"), fallback(Input::from("./flake.lock")))]
+        #[bpaf(positional("FILE"), fallback(Input::from("./flake.lock")))]
         lock_file: Input,
     },
     #[bpaf(command("count"))]
@@ -55,7 +55,7 @@ enum Command {
         output_opts: OutputOptions,
         /// The path of `flake.lock` to read, or `-` to read from standard input.
         /// If unspecified, defaults to the current directory.
-        #[bpaf(positional("INPUT"), fallback(Input::from("./flake.lock")))]
+        #[bpaf(positional("FILE"), fallback(Input::from("./flake.lock")))]
         lock_file: Input,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,11 @@ enum Command {
         /// Do not imitate `inputs.*.follows`, reference node indices instead
         #[bpaf(long, long("indexed"))]
         no_follows: bool,
+        /// Ignore the `ref` of an input by name. This will substitute transitive inputs
+        /// with a top-level input of this name, even if they are on different branches.
+        /// This option can be specified multiple times.
+        #[bpaf(short('R'), long("relax-input"), argument("INPUT"))]
+        relaxed_inputs: Vec<String>,
         /// Do not minify the output JSON
         #[bpaf(short('p'), long)]
         pretty: bool,
@@ -103,6 +108,7 @@ fn main() {
     match Command::from_env() {
         Command::Prune {
             no_follows,
+            relaxed_inputs,
             lock_file,
             pretty,
             output_opts:
@@ -119,7 +125,7 @@ fn main() {
             eprintln!();
             elogln!(:bold :bright_magenta "Flake input nodes' reference counts:"; &node_hits);
 
-            substitute_flake_inputs_with_follows(&lock, no_follows);
+            substitute_flake_inputs_with_follows(&lock, no_follows, &relaxed_inputs);
             eprintln!();
             prune_orphan_nodes(&mut lock);
 
@@ -210,7 +216,11 @@ fn serialize_to_json_output(value: impl Serialize, output: Output, overwrite: bo
     }
 }
 
-fn substitute_flake_inputs_with_follows(lock: &LockFile, indexed: bool) {
+fn substitute_flake_inputs_with_follows(
+    lock: &LockFile,
+    indexed: bool,
+    relaxed_inputs: &[impl AsRef<str>],
+) {
     elogln!(:bold :bright_magenta "Redirecting inputs to imitate follows behavior.");
 
     let root = lock.root().expect(EXPECT_ROOT_EXIST);
@@ -222,7 +232,7 @@ fn substitute_flake_inputs_with_follows(lock: &LockFile, indexed: bool) {
         let input = &*lock
             .get_node(&*input_index)
             .expect("a node to exist with this index");
-        substitute_node_inputs_with_root_inputs(lock, input, indexed);
+        substitute_node_inputs_with_root_inputs(lock, input, indexed, relaxed_inputs);
     }
 }
 
@@ -231,7 +241,12 @@ fn substitute_flake_inputs_with_follows(lock: &LockFile, indexed: bool) {
 ///
 /// Otherwise, if `indexed == true`, the each input replacement will be cloned
 /// verbatim from the root node, most likely retaining a `NodeEdge::Indexed`.
-fn substitute_node_inputs_with_root_inputs(lock: &LockFile, node: &Node, indexed: bool) {
+fn substitute_node_inputs_with_root_inputs(
+    lock: &LockFile,
+    node: &Node,
+    indexed: bool,
+    relaxed_inputs: &[impl AsRef<str>],
+) {
     let root = lock.root().expect(EXPECT_ROOT_EXIST);
     for (input_name, mut node_edge) in node.iter_edges_mut() {
         let Some(root_edge) = root.get_edge(input_name) else {
@@ -247,17 +262,25 @@ fn substitute_node_inputs_with_root_inputs(lock: &LockFile, node: &Node, indexed
         let Node::Locked(root_input) = &*lock.get_node_by_edge(&root_edge).unwrap() else {
             unreachable!("{}", MISSED_SANITY_CHECK);
         };
-        if input.original != root_input.original {
+
+        let relaxed_replace = relaxed_inputs
+            .iter()
+            .any(|ignore| input_name == ignore.as_ref());
+        let origins_match = input.original.iter().all(|(attr, value)| {
+            (attr == "ref" && relaxed_replace) || (Some(value) == root_input.original.get(attr))
+        });
+        if !origins_match {
             elogln!(
                 :bold (
                     :bright_red "Skipping", :cyan "replacement for", :yellow "'{node_edge}'",
                     :cyan "because", :purple "'{root_edge}'", :cyan "has a different origin."
                 );
-                (,, :yellow "Transitive input:", :blue (input.original));
-                (,, :purple "Top-level input:", :blue (root_input.original))
+                (,, :yellow "Transitive input:", :blue (serde_json::to_value(&input.original).unwrap()));
+                (,, :purple "Top-level input:", :blue (serde_json::to_value(&root_input.original).unwrap()))
             );
             continue;
         }
+
         if indexed {
             let old = std::mem::replace(&mut *node_edge, (*root_edge).clone());
             elogln!("-", :yellow "'{input_name}'", "now references", :italic :purple "'{node_edge}'", :dimmed "(was '{old}')");
@@ -378,7 +401,7 @@ mod tests {
     #[test]
     fn prune_hyprland_flake_lock() {
         let mut lock = read_flake_lock(HYPRLAND_LOCK_NO_FOLLOWS.into());
-        substitute_flake_inputs_with_follows(&lock, false);
+        substitute_flake_inputs_with_follows(&lock, false, &["nixpkgs"]);
         prune_orphan_nodes(&mut lock);
         insta::with_settings!(
             {


### PR DESCRIPTION
Assert that transitive inputs will not be substituted with those from the root flake unless they are from the same origin/remote resource.

This closes #14.